### PR TITLE
allow objects for textComponent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -268,7 +268,7 @@ export default class PhoneInput extends Component {
 const styleType = PropTypes.oneOfType([PropTypes.object, PropTypes.number]);
 
 PhoneInput.propTypes = {
-  textComponent: PropTypes.func,
+  textComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   initialCountry: PropTypes.string,
   onChangePhoneNumber: PropTypes.func,
   value: PropTypes.string,


### PR DESCRIPTION
Hey there,

` textComponent={MyInput}` now accepts objects (component classes)

It also addresses https://github.com/thegamenicorus/react-native-phone-input/issues/98

Also, could you enable issues on your fork?
