### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -268,7 +268,7 @@ export default class PhoneInput extends Component {
 const styleType = PropTypes.oneOfType([PropTypes.object, PropTypes.number]);
 
 PhoneInput.propTypes = {
-  textComponent: PropTypes.func,
+  textComponent: PropTypes.elementType,
   initialCountry: PropTypes.string,
   onChangePhoneNumber: PropTypes.func,
   value: PropTypes.string,


### PR DESCRIPTION
Hi,

If you pass a component as parameter to textComponent, I am receiving a warning:
Warning: Failed prop type: Invalid prop `textComponent` of type `object` supplied to `PhoneInput`, expected `function`.

```
<PhoneInput
textComponent={TextInput}
/>
```

The PropTypes don't look to be correct.